### PR TITLE
Load DB connection from environment

### DIFF
--- a/PTI2_Senac-main/README.md
+++ b/PTI2_Senac-main/README.md
@@ -67,6 +67,15 @@ Linguagem de programação utilizada para a automação dos processos de **extra
   - Baixar o arquivo "Script DML carregar base sidra_mysql.py" do repositório (https://github.com/valdecircarlos/PI_Senac/blob/main/Script%20DML%20carregar%20base%20sidra_mysql.py)
   - Abra o Prompt de Comando do Windows
   - Acesse o Diretório onde o arquivo de Script "Script DML carregar base sidra_mysql.py" foi salvo.
+  - Defina as variáveis de ambiente de conexão antes da execução:
+
+    ```bash
+    set MYSQL_HOST=127.0.0.1
+    set MYSQL_USER=root
+    set MYSQL_PASSWORD=suasenha
+    set MYSQL_DATABASE=sidra
+    ```
+    *(use `export` em sistemas Unix)*
   - Executar o "Script DML carregar base sidra_mysql.py" no Prompt de comando
 
 ---

--- a/PTI2_Senac-main/Script DML carregar base sidra_mysql.py
+++ b/PTI2_Senac-main/Script DML carregar base sidra_mysql.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import mysql.connector
 
@@ -5,10 +6,10 @@ import mysql.connector
 def conectar_mysql():
     try:
         conn = mysql.connector.connect(
-            host="127.0.0.1",
-            user="root",
-            password="G@mes8090",
-            database="sidra"
+            host=os.getenv("MYSQL_HOST", "127.0.0.1"),
+            user=os.getenv("MYSQL_USER", "root"),
+            password=os.getenv("MYSQL_PASSWORD", "G@mes8090"),
+            database=os.getenv("MYSQL_DATABASE", "sidra")
         )
         print("✅ Conectado ao MySQL com sucesso.")
         return conn


### PR DESCRIPTION
## Summary
- read MySQL connection parameters from environment variables in `Script DML carregar base sidra_mysql.py`
- document environment variables in README

## Testing
- `python -m py_compile 'Script DML carregar base sidra_mysql.py'`

------
https://chatgpt.com/codex/tasks/task_e_6873288bacc08333849544a0bbc923f2